### PR TITLE
mode: ignore 'default' modefile

### DIFF
--- a/buck/mode/.gitignore
+++ b/buck/mode/.gitignore
@@ -1,0 +1,1 @@
+default


### PR DESCRIPTION
There's a convenient trick where you can define a default modefile like:

    @mode//cached-upload
    @mode//local

And then always refer to it with @mode//default -- so we'll just ignore this file.