### PR TITLE
buck: allow 'BUCK' as a buildfile name

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -15,8 +15,9 @@ third-party = depot-third-party
 tilde = depot-tilde
 
 [buildfile]
-# 'BUILD' is a much better noun than 'BUCK'...
-name = BUILD
+# 'BUILD' is a much better noun than 'BUCK', but sometimes BUCK is needed
+# when there are conflicts in case insensitive filesystems like macOS...
+name = BUILD,BUCK
 
 # for the sake of future compatibility and migrations, we don't want any BUILD
 # files in the project to use raw, un-imported symbols from the prelude like

--- a/.buckconfig.d/cells-common.include
+++ b/.buckconfig.d/cells-common.include
@@ -1,5 +1,5 @@
 [buildfile]
 # [ref:buildfile-names]
-name = BUILD
+name = BUILD,BUCK
 # [ref:noprelude-dot-bzl]
 includes = root//buck/shims/noprelude.bzl


### PR DESCRIPTION
On case insensitive filesystems like APFS/macOS, you can't have a directory and file both named "build" because it will confuse everything.

Just extend the list of acceptable buildfile names to include 'BUCK' so that we can use that instead. Needed for an upcoming diff.