### PR TITLE
third-party//rust: add 'hyper' dependency

### DIFF
--- a/buck/third-party/rust/BUILD
+++ b/buck/third-party/rust/BUILD
@@ -9804,6 +9804,12 @@ third_party_rust.rust_library(
     deps = [":typenum-1.19.0"],
 )
 
+shims.alias(
+    name = "hyper",
+    actual = ":hyper-1.8.1",
+    visibility = ["PUBLIC"],
+)
+
 shims.http_archive(
     name = "hyper-1.8.1.crate",
     sha256 = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11",

--- a/buck/third-party/rust/Cargo.lock
+++ b/buck/third-party/rust/Cargo.lock
@@ -7229,6 +7229,7 @@ dependencies = [
  "hmac 0.12.1",
  "http",
  "http-body-util",
+ "hyper",
  "hyper-util",
  "insta",
  "iocraft",

--- a/buck/third-party/rust/Cargo.toml
+++ b/buck/third-party/rust/Cargo.toml
@@ -58,6 +58,7 @@ hex = "0.4.3"
 hmac = "0.12"
 http = "1.3.1"
 http-body-util = "0.1"
+hyper = "1.8.1"
 hyper-util = { version = "0.1", features = ["server-auto", "server-graceful", "http1", "http2", "tokio"] }
 insta = "1.42.2"
 iocraft = "0.7.10"


### PR DESCRIPTION
It was already included transitively.