### PR TITLE
third-party//rust: update slatedb 0.11.1 -> 0.11.2

### DIFF
--- a/buck/third-party/rust/Cargo.toml
+++ b/buck/third-party/rust/Cargo.toml
@@ -89,7 +89,7 @@ salsa = "0.22.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = { version = "0.10", features = ["compress"] }
-slatedb = "0.11.1"
+slatedb = "0.11.2"
 syn = { version = "2.0.110", features = ["full"] }
 tar = "0.4"
 tempfile = "3.20.0"


### PR DESCRIPTION
This is already in the BUILD file as it was picked up by a recent 'cargo update'