### PR TITLE
cache-server: add dial9+tonic handler crate

### DIFF
--- a/src/tools/cache-server/BUILD
+++ b/src/tools/cache-server/BUILD
@@ -7,6 +7,7 @@ BUILD_DEPS = [
     # 3p deps
     'third-party//mimalloc:rust',
     # local deps
+    '//src/tools/cache-server/dial9-tonic:dial9-tonic',
     '//src/tools/cache-server/protos:protos',
     '//src/tools/cache-server/storage:storage',
     '//src/tools/cache-server/telemetry:telemetry',
@@ -18,6 +19,7 @@ BUILD_DEPS = [
     'third-party//rust:sha2',
     'third-party//rust:anyhow',
     'third-party//rust:clap',
+    'third-party//rust:dial9-tokio-telemetry',
     'third-party//rust:console-subscriber',
     'third-party//rust:prost',
     'third-party//rust:prost-types',
@@ -25,6 +27,8 @@ BUILD_DEPS = [
     'third-party//rust:tokio-stream',
     'third-party//rust:tonic',
     'third-party//rust:tower',
+    'third-party//rust:hyper',
+    'third-party//rust:hyper-util',
     'third-party//rust:tonic-prost',
     'third-party//rust:tonic-health',
     'third-party//rust:tonic-reflection',

--- a/src/tools/cache-server/dial9-tonic/BUILD
+++ b/src/tools/cache-server/dial9-tonic/BUILD
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: © 2026 Austin Seipp
+# SPDX-License-Identifier: Apache-2.0
+
+load("@root//buck/shims:shims.bzl", depot="shims")
+
+DEPS = [
+    'third-party//rust:bytes',
+    'third-party//rust:dial9-tokio-telemetry',
+    'third-party//rust:futures',
+    'third-party//rust:hyper',
+    'third-party//rust:hyper-util',
+    'third-party//rust:tokio',
+    'third-party//rust:tower',
+    'third-party//rust:tracing',
+]
+
+depot.rust_library(
+    name = 'dial9-tonic',
+    srcs = glob(['*.rs']),
+    deps = DEPS,
+    visibility = ['//src/tools/cache-server/...'],
+)
+
+depot.rust_test(
+    name = 'tests',
+    srcs = glob(['*.rs']),
+    deps = DEPS,
+)

--- a/src/tools/cache-server/dial9-tonic/lib.rs
+++ b/src/tools/cache-server/dial9-tonic/lib.rs
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: © 2026 Austin Seipp
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+//! Traced gRPC server: routes every per-connection and HTTP/2-internal spawn
+//! through [`TelemetryHandle::spawn`] so that scheduling delays are captured
+//! by the dial9 telemetry system.
+//!
+//! Adapted from the dial9 `axum_traced.rs` example for tonic services.
+
+use std::{future::Future, pin::pin, time::Duration};
+
+use dial9_tokio_telemetry::telemetry::TelemetryHandle;
+use futures::FutureExt as _;
+use hyper::body::Incoming;
+use hyper_util::{
+    rt::{TokioIo, TokioTimer},
+    server::conn::auto::Builder,
+    service::TowerToHyperService,
+};
+use tokio::{net::TcpListener, sync::watch};
+use tower::Service;
+
+// -------------------------------------------------------------------------------------------------
+
+/// A hyper executor that routes spawns through dial9's [`TelemetryHandle`]
+/// so HTTP/2 internal tasks get wake event tracking.
+#[derive(Clone)]
+struct TracedExecutor {
+    handle: TelemetryHandle,
+}
+
+impl<Fut> hyper::rt::Executor<Fut> for TracedExecutor
+where
+    Fut: Future + Send + 'static,
+    Fut::Output: Send + 'static,
+{
+    fn execute(&self, fut: Fut) {
+        self.handle.spawn(fut);
+    }
+}
+
+// -------------------------------------------------------------------------------------------------
+
+/// Serve a tower [`Service`] over TCP with traced spawning.
+///
+/// Every accepted connection is spawned via `handle.spawn()` and hyper's
+/// internal HTTP/2 tasks use a [`TracedExecutor`] — giving full scheduling
+/// delay visibility to the telemetry system.
+pub async fn serve_traced<S, ResBody>(
+    listener: TcpListener,
+    service: S,
+    handle: TelemetryHandle,
+    shutdown: impl Future<Output = ()> + Send + 'static,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    S: Service<hyper::Request<Incoming>, Response = hyper::Response<ResBody>>
+        + Clone
+        + Send
+        + 'static,
+    S::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+    S::Future: Send,
+    ResBody: hyper::body::Body<Data = bytes::Bytes> + Send + 'static,
+    ResBody::Error: Into<Box<dyn std::error::Error + Send + Sync>>,
+{
+    let (signal_tx, signal_rx) = watch::channel(());
+    handle.spawn(async move {
+        shutdown.await;
+        drop(signal_rx);
+    });
+
+    let (close_tx, close_rx) = watch::channel(());
+
+    loop {
+        let (stream, _addr) = tokio::select! {
+            conn = listener.accept() => conn?,
+            _ = signal_tx.closed() => break,
+        };
+
+        stream.set_nodelay(true)?;
+
+        let io = TokioIo::new(stream);
+        let svc = service.clone();
+        let hyper_service = TowerToHyperService::new(svc);
+        let signal_tx = signal_tx.clone();
+        let close_rx = close_rx.clone();
+        let traced_handle = handle.clone();
+
+        handle.spawn(async move {
+            let mut builder = Builder::new(TracedExecutor {
+                handle: traced_handle,
+            });
+
+            // HTTP/2 settings — replicate the previous tonic::transport::Server config.
+            builder
+                .http2()
+                .timer(TokioTimer::new())
+                .initial_connection_window_size(16 * 1024 * 1024) // 16 MiB
+                .initial_stream_window_size(8 * 1024 * 1024) // 8 MiB
+                .adaptive_window(true)
+                .max_frame_size(1024 * 1024) // 1 MiB
+                .keep_alive_interval(Some(Duration::from_secs(30)))
+                .keep_alive_timeout(Duration::from_secs(10));
+
+            let conn = builder.serve_connection_with_upgrades(io, hyper_service);
+            let mut conn = pin!(conn);
+            let mut signal_closed = pin!(signal_tx.closed().fuse());
+
+            loop {
+                tokio::select! {
+                    result = conn.as_mut() => {
+                        if let Err(_err) = result {
+                            tracing::trace!("failed to serve connection: {_err:#}");
+                        }
+                        break;
+                    }
+                    _ = &mut signal_closed => {
+                        conn.as_mut().graceful_shutdown();
+                    }
+                }
+            }
+            drop(close_rx);
+        });
+    }
+
+    drop(close_rx);
+    drop(listener);
+    close_tx.closed().await;
+    Ok(())
+}

--- a/src/tools/cache-server/src/main.rs
+++ b/src/tools/cache-server/src/main.rs
@@ -3,10 +3,13 @@
 
 //! Happy Fun Ball. Do not taunt.
 
-use std::{str::FromStr, sync::Arc};
+use std::{path::PathBuf, str::FromStr, sync::Arc};
 
 use anyhow::{Context, Result};
 use clap::Parser;
+use dial9_tokio_telemetry::telemetry::{
+    CpuProfilingConfig, RotatingWriter, SchedEventConfig, TelemetryHandle, TracedRuntime,
+};
 use tracing_subscriber::{filter, prelude::*};
 
 // ---------------------------------------------------------------------------------------------------------------------
@@ -79,12 +82,64 @@ struct Cli {
     /// Default TTL for cache entries in days (0 = no expiry).
     #[arg(long, default_value_t = 30, env = "CACHE_SERVER_DEFAULT_TTL_DAYS")]
     default_ttl_days: u32,
+
+    // --- Tracing options ---
+    /// Directory for dial9 runtime trace output. Defaults to
+    /// $TMPDIR/cache-server-traces.
+    #[arg(long, env = "CACHE_SERVER_TRACE_DIR")]
+    trace_dir: Option<PathBuf>,
+
+    /// Maximum size per trace segment file in MiB.
+    #[arg(long, default_value_t = 10, env = "CACHE_SERVER_TRACE_MAX_FILE_MIB")]
+    trace_max_file_mib: u64,
+
+    /// Maximum total trace disk usage in MiB.
+    #[arg(long, default_value_t = 50, env = "CACHE_SERVER_TRACE_MAX_TOTAL_MIB")]
+    trace_max_total_mib: u64,
 }
 
-#[tokio::main]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
     let cli = Cli::parse();
 
+    let trace_dir = cli
+        .trace_dir
+        .clone()
+        .unwrap_or_else(|| std::env::temp_dir().join("cache-server-traces"));
+    let _ = std::fs::remove_dir_all(&trace_dir);
+
+    let trace_path = trace_dir.join("trace.bin");
+    let writer = RotatingWriter::builder()
+        .base_path(&trace_path)
+        .max_file_size(cli.trace_max_file_mib * 1024 * 1024)
+        .max_total_size(cli.trace_max_total_mib * 1024 * 1024)
+        .build()?;
+
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.enable_all();
+
+    let (runtime, guard) = TracedRuntime::builder()
+        .with_task_tracking(true)
+        .with_cpu_profiling(CpuProfilingConfig::default())
+        .with_sched_events(SchedEventConfig {
+            include_kernel: true,
+        })
+        .with_trace_path(&trace_path)
+        .build_and_start(builder, writer)?;
+    let handle = guard.handle();
+    runtime.block_on(async {
+        let result = async_main(cli, handle, trace_dir).await;
+        // Give the background worker time to symbolize the final trace segment
+        // before exiting. Without this, Drop hard-kills the worker and stack
+        // traces are left as raw addresses.
+        guard
+            .graceful_shutdown(std::time::Duration::from_secs(5))
+            .await
+            .ok();
+        result
+    })
+}
+
+async fn async_main(cli: Cli, handle: TelemetryHandle, trace_dir: PathBuf) -> Result<()> {
     // Build OTEL config from env + CLI
     let otel_config = telemetry::OtelConfig::from_env().with_cli_overrides(
         if cli.otel_enabled { Some(true) } else { None },
@@ -177,6 +232,7 @@ async fn main() -> Result<()> {
         otel = otel_config.enabled,
         request_timeout_secs = cli.request_timeout,
         max_concurrent_requests = cli.max_concurrent_requests,
+        trace_dir = %trace_dir.display(),
         "cache-server ready",
     );
 
@@ -215,6 +271,7 @@ async fn main() -> Result<()> {
                     None
                 },
                 Some(cli.max_concurrent_requests),
+                handle,
         ) => r,
         _ = drain_deadline => Ok(()),
     };

--- a/src/tools/cache-server/src/reapi_grpc.rs
+++ b/src/tools/cache-server/src/reapi_grpc.rs
@@ -3,6 +3,8 @@
 
 use std::{net::SocketAddr, sync::Arc, time::Duration};
 
+use dial9_tokio_telemetry::telemetry::TelemetryHandle;
+
 use crate::store::CacheStore;
 
 use protos::google::bytestream::byte_stream_server::ByteStreamServer;
@@ -24,6 +26,7 @@ pub async fn start_reapi_grpc(
     store: Arc<CacheStore>,
     request_timeout: Option<Duration>,
     max_concurrent_requests: Option<usize>,
+    handle: TelemetryHandle,
 ) -> Result<(), Box<dyn std::error::Error>> {
     use crate::service;
 
@@ -53,9 +56,9 @@ pub async fn start_reapi_grpc(
         .set_serving::<LogStreamServiceServer<service::LogStreamSvc>>()
         .await;
 
-    let cas_service = service::ContentAddressableStorageService::new(store.clone());
+    let cas_service = service::ContentAddressableStorageService::new(store.clone(), handle.clone());
     let action_cache_service = service::ActionCacheService::new(store.clone());
-    let bytestream_service = service::ByteStreamService::new(store.clone());
+    let bytestream_service = service::ByteStreamService::new(store.clone(), handle.clone());
     let execution_service = service::ExecutionService::default();
     let capabilities_service = service::CapabilitiesService::default();
     let operations_service = service::OperationsService::default();
@@ -68,25 +71,9 @@ pub async fn start_reapi_grpc(
         .build_v1()
         .unwrap();
 
-    let mut server = tonic::transport::Server::builder()
-        .initial_connection_window_size(16 * 1024 * 1024) // 16 MiB
-        .initial_stream_window_size(8 * 1024 * 1024) // 8 MiB
-        .http2_adaptive_window(Some(true))
-        .max_frame_size(Some(1024 * 1024)) // 1 MiB (default 16 KiB)
-        .tcp_nodelay(true)
-        .tcp_keepalive(Some(std::time::Duration::from_secs(60)))
-        .http2_keepalive_interval(Some(std::time::Duration::from_secs(30)))
-        .http2_keepalive_timeout(Some(std::time::Duration::from_secs(10)))
-        .concurrency_limit_per_connection(256);
-
-    if let Some(timeout) = request_timeout {
-        server = server.timeout(timeout);
-    }
-
-    let effective_limit = max_concurrent_requests.unwrap_or(8192);
-    server
-        .layer(tower::limit::ConcurrencyLimitLayer::new(effective_limit))
-        .add_service(CapabilitiesServer::new(capabilities_service))
+    // Build routes using tonic::service::Routes directly — we bypass tonic's
+    // transport layer so we can run our own traced accept loop.
+    let routes = tonic::service::Routes::new(CapabilitiesServer::new(capabilities_service))
         .add_service(ContentAddressableStorageServer::new(cas_service))
         .add_service(ActionCacheServer::new(action_cache_service))
         .add_service(ExecutionServer::new(execution_service))
@@ -97,7 +84,22 @@ pub async fn start_reapi_grpc(
         .add_service(LogStreamServiceServer::new(logstream_service))
         .add_service(health_service)
         .add_service(reflection_service)
-        .serve_with_shutdown(address, shutdown)
-        .await?;
-    Ok(())
+        .prepare();
+
+    let effective_limit = max_concurrent_requests.unwrap_or(8192);
+
+    let listener = tokio::net::TcpListener::bind(address).await?;
+
+    // Apply global concurrency limit, then optionally a per-request timeout.
+    // The two branches avoid complex type-erasure; serve_traced is generic.
+    if let Some(timeout) = request_timeout {
+        let svc = tower::limit::ConcurrencyLimit::new(
+            tower::timeout::Timeout::new(routes, timeout),
+            effective_limit,
+        );
+        dial9_tonic::serve_traced(listener, svc, handle, shutdown).await
+    } else {
+        let svc = tower::limit::ConcurrencyLimit::new(routes, effective_limit);
+        dial9_tonic::serve_traced(listener, svc, handle, shutdown).await
+    }
 }

--- a/src/tools/cache-server/src/service/bytestream.rs
+++ b/src/tools/cache-server/src/service/bytestream.rs
@@ -3,6 +3,7 @@
 
 use std::sync::Arc;
 
+use dial9_tokio_telemetry::telemetry::TelemetryHandle;
 use futures::StreamExt as _;
 use tokio_stream::wrappers::ReceiverStream;
 
@@ -21,14 +22,23 @@ const READ_CHUNK_SIZE: usize = 2 * 1024 * 1024; // 2 MiB
 
 // ---------------------------------------------------------------------------------------------------------------------
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct ByteStreamService {
     store: Arc<CacheStore>,
+    handle: TelemetryHandle,
+}
+
+impl std::fmt::Debug for ByteStreamService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ByteStreamService")
+            .field("store", &self.store)
+            .finish_non_exhaustive()
+    }
 }
 
 impl ByteStreamService {
-    pub fn new(store: Arc<CacheStore>) -> Self {
-        Self { store }
+    pub fn new(store: Arc<CacheStore>, handle: TelemetryHandle) -> Self {
+        Self { store, handle }
     }
 
     /// Process a sequence of write messages and store the resulting blob.
@@ -192,6 +202,7 @@ impl byte_stream_server::ByteStream for ByteStreamService {
         req: tonic::Request<ReadRequest>,
     ) -> Result<tonic::Response<Self::ReadStream>, tonic::Status> {
         let store = self.store.clone();
+        let handle = self.handle.clone();
         instrumented_rpc("bytestream.read", async move {
             let inner = req.into_inner();
             let parsed = parse_read_resource_name(&inner.resource_name)?;
@@ -266,7 +277,7 @@ impl byte_stream_server::ByteStream for ByteStreamService {
             let compressor = parsed.compressor;
             let (tx, rx) = tokio::sync::mpsc::channel(32);
 
-            tokio::spawn(async move {
+            handle.spawn(async move {
                 let m = telemetry::metrics();
                 let svc_attr = telemetry::KeyValue::new("service", "bytestream");
 

--- a/src/tools/cache-server/src/service/cas.rs
+++ b/src/tools/cache-server/src/service/cas.rs
@@ -4,6 +4,7 @@
 use std::sync::Arc;
 
 use bytes::Bytes;
+use dial9_tokio_telemetry::telemetry::TelemetryHandle;
 use futures::{StreamExt as _, TryStreamExt as _};
 use prost::Message;
 use tokio_stream::wrappers::ReceiverStream;
@@ -30,14 +31,23 @@ const MAX_BATCH_DIGESTS: usize = 10_000;
 
 // ---------------------------------------------------------------------------------------------------------------------
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct ContentAddressableStorageService {
     store: Arc<CacheStore>,
+    handle: TelemetryHandle,
+}
+
+impl std::fmt::Debug for ContentAddressableStorageService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ContentAddressableStorageService")
+            .field("store", &self.store)
+            .finish_non_exhaustive()
+    }
 }
 
 impl ContentAddressableStorageService {
-    pub fn new(store: Arc<CacheStore>) -> Self {
-        Self { store }
+    pub fn new(store: Arc<CacheStore>, handle: TelemetryHandle) -> Self {
+        Self { store, handle }
     }
 }
 
@@ -397,6 +407,7 @@ impl content_addressable_storage_server::ContentAddressableStorage
         req: tonic::Request<GetTreeRequest>,
     ) -> Result<tonic::Response<Self::GetTreeStream>, tonic::Status> {
         let store = self.store.clone();
+        let handle = self.handle.clone();
         instrumented_rpc("cas.get_tree", async move {
             let inner = req.into_inner();
             let digest_fn = resolve_digest_function(inner.digest_function)?;
@@ -421,7 +432,7 @@ impl content_addressable_storage_server::ContentAddressableStorage
             // Stream directories as they are decoded instead of
             // accumulating them all in memory first.
             let (tx, rx) = tokio::sync::mpsc::channel(32);
-            tokio::spawn(async move {
+            handle.spawn(async move {
                 let mut queue = std::collections::VecDeque::new();
                 let mut visited = std::collections::HashSet::new();
                 queue.push_back(root_cd.clone());

--- a/src/tools/cache-server/src/service/tests.rs
+++ b/src/tools/cache-server/src/service/tests.rs
@@ -14,6 +14,8 @@ use protos::build::bazel::remote::execution::v2::{
 };
 use protos::google::bytestream::{ReadRequest, WriteRequest, byte_stream_server::ByteStream};
 
+use dial9_tokio_telemetry::telemetry::{TelemetryHandle, TracedRuntime};
+
 use crate::store::{
     CacheStore, CacheStoreSettings, Compression, ContentDigest, DigestFn, StoreBackend,
 };
@@ -30,6 +32,20 @@ fn ensure_telemetry() {
     INIT_TELEMETRY.call_once(|| {
         telemetry::init_metrics(&telemetry::OtelConfig::default()).unwrap();
     });
+}
+
+fn test_handle() -> TelemetryHandle {
+    static HANDLE: std::sync::LazyLock<TelemetryHandle> = std::sync::LazyLock::new(|| {
+        let mut b = tokio::runtime::Builder::new_current_thread();
+        b.enable_all();
+        // Leak the runtime + guard so they live for the process lifetime.
+        let (rt, guard) = TracedRuntime::build_disabled(b).unwrap();
+        let handle = guard.handle();
+        std::mem::forget(rt);
+        std::mem::forget(guard);
+        handle
+    });
+    HANDLE.clone()
 }
 
 fn sha256(data: &[u8]) -> [u8; 32] {
@@ -53,7 +69,7 @@ async fn make_store() -> Arc<CacheStore> {
 }
 
 fn make_cas(store: Arc<CacheStore>) -> ContentAddressableStorageService {
-    ContentAddressableStorageService::new(store)
+    ContentAddressableStorageService::new(store, test_handle())
 }
 
 fn make_ac(store: Arc<CacheStore>) -> ActionCacheService {
@@ -61,7 +77,7 @@ fn make_ac(store: Arc<CacheStore>) -> ActionCacheService {
 }
 
 fn make_bs(store: Arc<CacheStore>) -> ByteStreamService {
-    ByteStreamService::new(store)
+    ByteStreamService::new(store, test_handle())
 }
 
 // =================================================================================================================


### PR DESCRIPTION
This module automatically instruments all gRPC connections with dial9's spawn functions in order to capture scheduler delays via wakeup tracking.