### PR TITLE
cache-server: add PACKAGE, only for config//os:linux

### DIFF
--- a/src/tools/cache-server/BUILD
+++ b/src/tools/cache-server/BUILD
@@ -7,9 +7,9 @@ BUILD_DEPS = [
     # 3p deps
     'third-party//mimalloc:rust',
     # local deps
-    ':protos',
-    ':storage',
-    ':telemetry',
+    '//src/tools/cache-server/protos:protos',
+    '//src/tools/cache-server/storage:storage',
+    '//src/tools/cache-server/telemetry:telemetry',
     # crates.io
     'third-party//rust:bytes',
     'third-party//rust:futures',
@@ -44,25 +44,4 @@ depot.rust_test(
     srcs = glob(['src/**/*.rs']),
     crate_root = 'src/main.rs',
     deps = BUILD_DEPS,
-)
-
-# Protos library is now in protos/BUILD
-depot.alias(
-    name = 'protos',
-    actual = '//src/tools/cache-server/protos:protos',
-    visibility = [],
-)
-
-# Storage library is in storage/BUILD
-depot.alias(
-    name = 'storage',
-    actual = '//src/tools/cache-server/storage:storage',
-    visibility = [],
-)
-
-# Telemetry library is in telemetry/BUILD
-depot.alias(
-    name = 'telemetry',
-    actual = '//src/tools/cache-server/telemetry:telemetry',
-    visibility = [],
 )

--- a/src/tools/cache-server/PACKAGE
+++ b/src/tools/cache-server/PACKAGE
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: © 2024-2026 Austin Seipp
+# SPDX-License-Identifier: Apache-2.0
+
+load("@root//buck/shims:package.bzl", "pkg")
+
+pkg.info(
+    copyright = ["© 2024-2026 Austin Seipp"],
+    license = "Apache-2.0",
+    description = "Remote Execution API Service",
+    version = "1.0.0",
+    visibility = ["PUBLIC"],
+    target_compatible_with = [
+        "config//os:linux",
+    ],
+    inherit = True,
+)


### PR DESCRIPTION
Right now there are some build complications with dial9 on macOS, but I want to start using cgroups/PSI information to size caches soon so lets just axe support for right now.