### PR TITLE
buck: add support for customizable installers

### DIFF
--- a/buck/installers/PACKAGE
+++ b/buck/installers/PACKAGE
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: © 2024-2026 Austin Seipp
+# SPDX-License-Identifier: Apache-2.0
+
+load("@root//buck/shims:package.bzl", "pkg")
+
+pkg.info(
+    copyright = ["© 2024-2026 Austin Seipp"],
+    license = "Apache-2.0",
+    description = "Buck2 installer framework",
+    version = "0.1.0",
+    visibility = ["PUBLIC"],
+    inherit = True,
+)

--- a/buck/installers/common/BUILD
+++ b/buck/installers/common/BUILD
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: © 2024-2026 Austin Seipp
+# SPDX-License-Identifier: Apache-2.0
+
+load("@root//buck/shims:shims.bzl", depot = "shims")
+
+depot.rust_library(
+    name = 'common',
+    srcs = ['lib.rs'],
+    deps = [
+        '//buck/installers/proto:proto',
+        'third-party//rust:anyhow',
+        'third-party//rust:clap',
+        'third-party//rust:tokio',
+        'third-party//rust:tonic',
+        'third-party//rust:tracing',
+        'third-party//rust:tracing-subscriber',
+    ],
+    visibility = ['PUBLIC'],
+)

--- a/buck/installers/common/lib.rs
+++ b/buck/installers/common/lib.rs
@@ -1,0 +1,217 @@
+// SPDX-FileCopyrightText: © 2024-2026 Austin Seipp
+// SPDX-License-Identifier: Apache-2.0
+
+//! Common framework for Buck2 installer binaries.
+//!
+//! Provides the [`InstallerHandler`] trait and [`run_installer`] entry point.
+//! Installer implementations only need to implement the trait and call the
+//! entry point from their `main()`.
+
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::Result;
+use tokio::sync::Notify;
+use tonic::{Request, Response, Status};
+
+pub use proto::installer_server::InstallerServer;
+pub use proto::{DeviceMetadata, ErrorCategory, ErrorDetail};
+
+/// Re-export so downstream crates don't need a direct tonic dependency.
+pub use tonic::async_trait;
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+/// Common CLI arguments that buck2 passes to every installer.
+///
+/// Installer binaries should flatten this into their own `#[derive(clap::Parser)]`
+/// struct so that installer-specific arguments are parsed alongside these:
+///
+/// ```ignore
+/// #[derive(clap::Parser)]
+/// struct MyArgs {
+///     #[command(flatten)]
+///     common: common::InstallerArgs,
+///
+///     #[arg(long)]
+///     my_custom_flag: bool,
+/// }
+/// ```
+#[derive(clap::Args, Debug)]
+pub struct InstallerArgs {
+    /// TCP port to listen on (assigned by buck2)
+    #[arg(long = "tcp-port")]
+    pub tcp_port: u16,
+
+    /// Path for installer log output
+    #[arg(long = "log-path")]
+    pub log_path: PathBuf,
+}
+
+// ---------------------------------------------------------------------------
+// Handler trait
+// ---------------------------------------------------------------------------
+
+/// Metadata about a file that buck2 has materialized and is ready for install.
+pub struct FileReadyInfo {
+    pub install_id: String,
+    pub name: String,
+    pub path: PathBuf,
+    pub digest: String,
+    pub digest_algorithm: String,
+    pub size: u64,
+}
+
+/// Result returned by [`InstallerHandler::file_ready`].
+pub struct FileResult {
+    pub error: Option<ErrorDetail>,
+    pub device_metadata: Vec<DeviceMetadata>,
+}
+
+impl Default for FileResult {
+    fn default() -> Self {
+        Self {
+            error: None,
+            device_metadata: Vec::new(),
+        }
+    }
+}
+
+/// Trait that installer implementations must provide.
+///
+/// Each method corresponds to one of the gRPC RPCs in `install.proto`.
+#[tonic::async_trait]
+pub trait InstallerHandler: Send + Sync + 'static {
+    /// Called when buck2 announces an installation (target + expected files).
+    async fn install(&self, install_id: &str, file_names: &[String]) -> Result<()>;
+
+    /// Called when a single file has been materialized and is ready to install.
+    async fn file_ready(&self, info: FileReadyInfo) -> Result<FileResult>;
+
+    /// Called when buck2 asks the installer to shut down. Default is a no-op.
+    async fn shutdown(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// gRPC service implementation
+// ---------------------------------------------------------------------------
+
+struct InstallerService<H> {
+    handler: Arc<H>,
+    shutdown: Arc<Notify>,
+}
+
+#[tonic::async_trait]
+impl<H: InstallerHandler> proto::installer_server::Installer for InstallerService<H> {
+    async fn install(
+        &self,
+        request: Request<proto::InstallInfoRequest>,
+    ) -> std::result::Result<Response<proto::InstallResponse>, Status> {
+        let req = request.into_inner();
+        tracing::info!(install_id = %req.install_id, files = ?req.file_names, "install request");
+
+        self.handler
+            .install(&req.install_id, &req.file_names)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+
+        Ok(Response::new(proto::InstallResponse {
+            install_id: req.install_id,
+        }))
+    }
+
+    async fn file_ready(
+        &self,
+        request: Request<proto::FileReadyRequest>,
+    ) -> std::result::Result<Response<proto::FileResponse>, Status> {
+        let req = request.into_inner();
+        tracing::info!(
+            install_id = %req.install_id,
+            name = %req.name,
+            path = %req.path,
+            size = req.size,
+            "file ready"
+        );
+
+        let info = FileReadyInfo {
+            install_id: req.install_id.clone(),
+            name: req.name.clone(),
+            path: PathBuf::from(&req.path),
+            digest: req.digest,
+            digest_algorithm: req.digest_algorithm,
+            size: req.size,
+        };
+
+        let result = self
+            .handler
+            .file_ready(info)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+
+        Ok(Response::new(proto::FileResponse {
+            install_id: req.install_id,
+            name: req.name,
+            path: req.path,
+            error_detail: result.error,
+            device_metadata: result.device_metadata,
+        }))
+    }
+
+    async fn shutdown_server(
+        &self,
+        _request: Request<proto::ShutdownRequest>,
+    ) -> std::result::Result<Response<proto::ShutdownResponse>, Status> {
+        tracing::info!("shutdown requested");
+
+        self.handler
+            .shutdown()
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+
+        self.shutdown.notify_one();
+        Ok(Response::new(proto::ShutdownResponse {}))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+/// Set up logging, start the gRPC server, and dispatch RPCs to the provided
+/// handler. Returns when buck2 sends `ShutdownServer`.
+///
+/// Callers are responsible for parsing CLI arguments (including
+/// [`InstallerArgs`]) and constructing their handler before calling this.
+pub async fn run_installer<H: InstallerHandler>(args: &InstallerArgs, handler: H) -> Result<()> {
+    // Set up file-based logging
+    let log_file = std::fs::File::create(&args.log_path)?;
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(std::sync::Mutex::new(log_file))
+        .with_ansi(false)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber)?;
+
+    tracing::info!(port = args.tcp_port, "starting installer");
+
+    let shutdown = Arc::new(Notify::new());
+    let service = InstallerService {
+        handler: Arc::new(handler),
+        shutdown: shutdown.clone(),
+    };
+
+    let addr: SocketAddr = ([127, 0, 0, 1], args.tcp_port).into();
+    tracing::info!(%addr, "listening");
+
+    tonic::transport::Server::builder()
+        .add_service(InstallerServer::new(service))
+        .serve_with_shutdown(addr, shutdown.notified())
+        .await?;
+
+    tracing::info!("server shut down");
+    Ok(())
+}

--- a/buck/installers/defs.bzl
+++ b/buck/installers/defs.bzl
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: © 2024-2026 Austin Seipp
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rule for creating installable targets using buck2 install."""
+
+def _installable_impl(ctx: AnalysisContext) -> list[Provider]:
+    installer = ctx.attrs.installer
+    return [
+        DefaultInfo(),
+        InstallInfo(
+            installer = installer,
+            files = ctx.attrs.files,
+        ),
+    ]
+
+installable = rule(
+    impl = _installable_impl,
+    attrs = {
+        "files": attrs.dict(
+            key = attrs.string(),
+            value = attrs.source(),
+            default = {},
+        ),
+        "installer": attrs.label(),
+    },
+)

--- a/buck/installers/demo/BUILD
+++ b/buck/installers/demo/BUILD
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: © 2024-2026 Austin Seipp
+# SPDX-License-Identifier: Apache-2.0
+
+load("@root//buck/shims:shims.bzl", depot = "shims")
+load("//buck/installers:defs.bzl", "installable")
+
+depot.rust_binary(
+    name = 'demo',
+    srcs = ['main.rs'],
+    deps = [
+        '//buck/installers/common:common',
+        'third-party//rust:anyhow',
+        'third-party//rust:clap',
+        'third-party//rust:tokio',
+        'third-party//rust:tracing',
+        'third-party//rust:uuid',
+    ],
+)
+
+depot.genrule(
+    name = 'hello.txt',
+    cmd = 'echo "hello from buck2 install" > $OUT',
+    out = 'hello.txt',
+)
+
+installable(
+    name = 'demo-test',
+    installer = ':demo',
+    files = {
+        'hello.txt': ':hello.txt',
+    },
+)

--- a/buck/installers/demo/main.rs
+++ b/buck/installers/demo/main.rs
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: © 2024-2026 Austin Seipp
+// SPDX-License-Identifier: Apache-2.0
+
+//! Demo installer that copies files into a directory.
+//!
+//! By default, files are installed to `$TMPDIR/buck2-install-<uuid>/`.
+//! Use `--output-dir` to specify a custom destination:
+//!
+//! ```sh
+//! buck2 install //my:target -- --output-dir /path/to/dir
+//! ```
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use clap::Parser;
+use common::{FileReadyInfo, FileResult, InstallerArgs, InstallerHandler};
+
+#[derive(Parser, Debug)]
+#[command(name = "demo-installer")]
+struct Args {
+    #[command(flatten)]
+    common: InstallerArgs,
+
+    /// Directory to install files into. If not specified, a unique temporary
+    /// directory is created under $TMPDIR.
+    #[arg(long)]
+    output_dir: Option<PathBuf>,
+}
+
+struct DemoHandler {
+    dest_dir: PathBuf,
+}
+
+impl DemoHandler {
+    fn new(output_dir: Option<PathBuf>) -> Result<Self> {
+        let dest_dir = match output_dir {
+            Some(dir) => dir,
+            None => {
+                let id = uuid::Uuid::new_v4();
+                std::env::temp_dir().join(format!("buck2-install-{id}"))
+            }
+        };
+        std::fs::create_dir_all(&dest_dir)?;
+        println!(
+            "demo installer: files will be installed to {}",
+            dest_dir.display()
+        );
+        Ok(Self { dest_dir })
+    }
+}
+
+#[common::async_trait]
+impl InstallerHandler for DemoHandler {
+    async fn install(&self, install_id: &str, file_names: &[String]) -> Result<()> {
+        tracing::info!(
+            install_id,
+            ?file_names,
+            dest = %self.dest_dir.display(),
+            "received install request"
+        );
+        Ok(())
+    }
+
+    async fn file_ready(&self, info: FileReadyInfo) -> Result<FileResult> {
+        let dest = self.dest_dir.join(&info.name);
+        if let Some(parent) = dest.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+        tokio::fs::copy(&info.path, &dest).await?;
+        println!("  installed: {}", dest.display());
+        tracing::info!(
+            name = %info.name,
+            src = %info.path.display(),
+            dest = %dest.display(),
+            size = info.size,
+            "installed file"
+        );
+        Ok(FileResult::default())
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+    let handler = DemoHandler::new(args.output_dir)?;
+    common::run_installer(&args.common, handler).await
+}

--- a/buck/installers/proto/BUILD
+++ b/buck/installers/proto/BUILD
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: © 2024-2026 Austin Seipp
+# SPDX-License-Identifier: Apache-2.0
+
+load("@root//buck/shims:shims.bzl", depot = "shims")
+load("@toolchains//protoc:defs.bzl", "protoc_env")
+
+depot.http_file(
+    name = 'install.proto',
+    sha256 = '32e879b486432853de4b5bf65a9e36138c0c8c8b787010ff0b1daa6f6c44d78b',
+    urls = [
+        'https://raw.githubusercontent.com/facebook/buck2/b3f8aa4001/app/buck2_install_proto/install.proto',
+    ],
+)
+
+depot.rust_library(
+    name = 'proto',
+    srcs = ['lib.rs'],
+    deps = [
+        'third-party//rust:prost',
+        'third-party//rust:prost-types',
+        'third-party//rust:tonic',
+        'third-party//rust:tonic-prost',
+    ],
+    env = {
+        'PROTOBUFS': '$(location :protos.rs)',
+    },
+    visibility = ['PUBLIC'],
+)
+
+depot.rust_binary(
+    name = 'gen-protos',
+    srcs = ['generate.rs'],
+    crate_root = 'generate.rs',
+    deps = [
+        'third-party//rust:tonic-prost-build',
+        'third-party//rust:tonic-prost',
+    ],
+    visibility = [],
+)
+
+depot.genrule(
+    name = 'protos.rs',
+    cmd = '$(exe :gen-protos)',
+    out = '.',
+    srcs = [':install.proto'],
+    env = protoc_env(),
+    visibility = [],
+)

--- a/buck/installers/proto/generate.rs
+++ b/buck/installers/proto/generate.rs
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2024-2026 Austin Seipp
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{env, path::PathBuf};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let srcdir = env::var("SRCDIR").unwrap_or_else(|_| ".".to_string());
+    let out_dir =
+        PathBuf::from(env::var("OUT_DIR").or_else(|_| env::var("OUT").map_err(|_| "OUT not set"))?);
+
+    tonic_prost_build::configure()
+        .build_server(true)
+        .build_client(false)
+        .out_dir(out_dir.clone())
+        .compile_protos(&[format!("{}/install.proto", srcdir)], &[srcdir])
+        .unwrap_or_else(|e| panic!("protobuf compile error: {}", e));
+
+    println!("cargo:rustc-env=PROTOBUFS={}", out_dir.display());
+
+    Ok(())
+}

--- a/buck/installers/proto/lib.rs
+++ b/buck/installers/proto/lib.rs
@@ -1,0 +1,6 @@
+// SPDX-FileCopyrightText: © 2024-2026 Austin Seipp
+// SPDX-License-Identifier: Apache-2.0
+
+//! Generated protobuf/gRPC types for the Buck2 installer protocol.
+
+include!(concat!(env!("PROTOBUFS"), "/install.rs"));

--- a/buck/toolchains/protoc/BUILD
+++ b/buck/toolchains/protoc/BUILD
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: © 2024-2026 Austin Seipp
+# SPDX-License-Identifier: Apache-2.0
+
+load("@root//buck/shims:shims.bzl", "shims")
+
+shims.http_archive(
+    name = 'protoc-bin-vendored.tar.gz',
+    sha256 = '08f5cc8f522af7ba8f9f1a81f93bba94cef9312e5e644df4ecc08ea7ce9c40f7',
+    urls = [
+        'https://github.com/stepancheg/rust-protoc-bin-vendored/archive/20ebfb74aad5fb0f084ca2c2ebc0885b4ad18430.tar.gz',
+    ],
+    type = 'tar.gz',
+    strip_prefix = 'rust-protoc-bin-vendored-20ebfb74aad5fb0f084ca2c2ebc0885b4ad18430',
+    sub_targets = [
+        'protoc-bin-vendored-linux-aarch_64/bin/protoc',
+        'protoc-bin-vendored-linux-aarch_64/include',
+        'protoc-bin-vendored-linux-x86_64/bin/protoc',
+        'protoc-bin-vendored-linux-x86_64/include',
+        'protoc-bin-vendored-macos-x86_64/bin/protoc',
+        'protoc-bin-vendored-macos-x86_64/include',
+        'protoc-bin-vendored-win32/bin/protoc.exe',
+        'protoc-bin-vendored-win32/include',
+    ],
+)

--- a/buck/toolchains/protoc/defs.bzl
+++ b/buck/toolchains/protoc/defs.bzl
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: © 2024-2026 Austin Seipp
+# SPDX-License-Identifier: Apache-2.0
+
+def protoc_env():
+    """Returns an env dict with PROTOC and PROTOC_INCLUDE for use in genrules."""
+    return {
+        'PROTOC': select({
+            'config//cpu:arm64': select({
+                'config//os:linux': '$(location toolchains//protoc:protoc-bin-vendored.tar.gz[protoc-bin-vendored-linux-aarch_64/bin/protoc])',
+                'config//os:macos': '$(location toolchains//protoc:protoc-bin-vendored.tar.gz[protoc-bin-vendored-macos-x86_64/bin/protoc])',
+            }),
+            'config//cpu:x86_64': select({
+                'config//os:linux': '$(location toolchains//protoc:protoc-bin-vendored.tar.gz[protoc-bin-vendored-linux-x86_64/bin/protoc])',
+                'config//os:windows': '$(location toolchains//protoc:protoc-bin-vendored.tar.gz[protoc-bin-vendored-win32/bin/protoc.exe])',
+            }),
+        }),
+        'PROTOC_INCLUDE': select({
+            'config//cpu:arm64': select({
+                'config//os:linux': '$(location toolchains//protoc:protoc-bin-vendored.tar.gz[protoc-bin-vendored-linux-aarch_64/include])',
+                'config//os:macos': '$(location toolchains//protoc:protoc-bin-vendored.tar.gz[protoc-bin-vendored-macos-x86_64/include])',
+            }),
+            'config//cpu:x86_64': select({
+                'config//os:linux': '$(location toolchains//protoc:protoc-bin-vendored.tar.gz[protoc-bin-vendored-linux-x86_64/include])',
+                'config//os:windows': '$(location toolchains//protoc:protoc-bin-vendored.tar.gz[protoc-bin-vendored-win32/include])',
+            }),
+        }),
+    }

--- a/src/tools/cache-server/protos/BUCK
+++ b/src/tools/cache-server/protos/BUCK
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 load("@root//buck/shims:shims.bzl", depot="shims")
+load("@toolchains//protoc:defs.bzl", "protoc_env")
 
 depot.rust_library(
     name = 'protos',
@@ -34,48 +35,6 @@ depot.genrule(
     cmd = "$(exe :gen-protos)",
     out = ".",
     srcs = glob(['**/*.proto']),
-    env = {
-        'PROTOC': depot.select({
-            'config//cpu:arm64': depot.select({
-                'config//os:linux': '$(location :protoc-bin-vendored.tar.gz[protoc-bin-vendored-linux-aarch_64/bin/protoc])',
-                'config//os:macos': '$(location :protoc-bin-vendored.tar.gz[protoc-bin-vendored-macos-x86_64/bin/protoc])',
-            }),
-            'config//cpu:x86_64': depot.select({
-                'config//os:linux': '$(location :protoc-bin-vendored.tar.gz[protoc-bin-vendored-linux-x86_64/bin/protoc])',
-                'config//os:windows': '$(location :protoc-bin-vendored.tar.gz[protoc-bin-vendored-win32/bin/protoc.exe])',
-            })
-        }),
-        'PROTOC_INCLUDE': depot.select({
-            'config//cpu:arm64': depot.select({
-                'config//os:linux': '$(location :protoc-bin-vendored.tar.gz[protoc-bin-vendored-linux-aarch_64/include])',
-                'config//os:macos': '$(location :protoc-bin-vendored.tar.gz[protoc-bin-vendored-macos-x86_64/include])',
-            }),
-            'config//cpu:x86_64': depot.select({
-                'config//os:linux': '$(location :protoc-bin-vendored.tar.gz[protoc-bin-vendored-linux-x86_64/include])',
-                'config//os:windows': '$(location :protoc-bin-vendored.tar.gz[protoc-bin-vendored-win32/include])',
-            })
-        })
-    },
-    visibility = [],
-)
-
-depot.http_archive(
-    name = 'protoc-bin-vendored.tar.gz',
-    sha256 = '08f5cc8f522af7ba8f9f1a81f93bba94cef9312e5e644df4ecc08ea7ce9c40f7',
-    urls = [
-        'https://github.com/stepancheg/rust-protoc-bin-vendored/archive/20ebfb74aad5fb0f084ca2c2ebc0885b4ad18430.tar.gz',
-    ],
-    type = 'tar.gz',
-    strip_prefix = 'rust-protoc-bin-vendored-20ebfb74aad5fb0f084ca2c2ebc0885b4ad18430',
-    sub_targets = [
-        'protoc-bin-vendored-linux-aarch_64/bin/protoc',
-        'protoc-bin-vendored-linux-aarch_64/include',
-        'protoc-bin-vendored-linux-x86_64/bin/protoc',
-        'protoc-bin-vendored-linux-x86_64/include',
-        'protoc-bin-vendored-macos-x86_64/bin/protoc',
-        'protoc-bin-vendored-macos-x86_64/include',
-        'protoc-bin-vendored-win32/bin/protoc.exe',
-        'protoc-bin-vendored-win32/include',
-    ],
+    env = protoc_env(),
     visibility = [],
 )


### PR DESCRIPTION
`buck2 install` is open ended and configurable; it essentially works like this:

- Install target provides an `InstallInfo()` provider which has A) a target program and B) a list of files/artifacts
- Buck builds the target program, and runs it. It expects the program to spawn a TCP server with a gRPC endpoint on a specified port.
- Buck then uses a simple unidirectional protocol to transmit files to the installer service, which can do whatever it wants.

This means we can freely use `InstallInfo()` for things like installing to a directory, a tarball, a docker registry, a kube cluster, a nix store, etc, by implementing the proper installer. This adds some scaffolding to make it easy to write end-user installers in Rust, and then has a simple `demo` installer that just lets you install to a directory (`$TMPDIR` by default).