### PR TITLE
cellar//bootstrap: include all tools in `M2-Mesoplant` invocation

### DIFF
--- a/cellar/bootstrap/stage0-posix/mescc-tools-extra/defs.bzl
+++ b/cellar/bootstrap/stage0-posix/mescc-tools-extra/defs.bzl
@@ -3,17 +3,17 @@ def __cc(ctx: AnalysisContext) -> list[Provider]:
     output = ctx.actions.declare_output(ctx.label.name)
     tools = ctx.attrs.tools[DefaultInfo].default_outputs[0]
 
-    m2_mesoplanet = tools.project("M2-Mesoplanet")
+    m2libc = ctx.attrs._m2_libc[DefaultInfo].default_outputs[0]
     ctx.actions.run(
-        [
-            m2_mesoplanet,
+        cmd_args(
+            cmd_args(tools, format = "{}/M2-Mesoplanet"),
             "--operating-system", ctx.attrs.os,
             "--architecture", ctx.attrs.arch,
             "-f", ctx.attrs.src,
-            '-o', output.as_output()
-        ],
+            '-o', output.as_output(),
+        ),
         env = {
-            'M2LIBC_PATH': ctx.attrs._m2_libc[DefaultInfo].default_outputs[0],
+            'M2LIBC_PATH': m2libc,
             'PATH': tools,
         },
         category = "stage0_m2_mesoplanet",


### PR DESCRIPTION
`M2-Mesoplanet` was trying to invoke other commands (`M1`, `blood-elf`, etc) but the `.project()` call only included that one single binary in the command under the sandbox. Instead include `cmd_args(tools)` with a formatting option so that the entire directory comes in, instead.