### PR TITLE
buck: include execution platforms in configuration hashes

### DIFF
--- a/.buckconfig.d/001-common.buckconfig
+++ b/.buckconfig.d/001-common.buckconfig
@@ -53,6 +53,11 @@ starlark_max_callstack_size = 50
 # starlark_memory_limit() by default if no limit is specified.
 default_starlark_peak_memory = 5242880
 
+# include the execution platform in the configuration hash, so that execution
+# platforms get different hashes from target platforms with identical
+# constraints
+hash_cfg_with_exec_platform = true
+
 [buck2_re_client]
 # for larger blobs: set a larger gRPC timeout window so we can upload them in time
 grpc_timeout = 900


### PR DESCRIPTION
See the included comment; this apparently works around a bug that was recently introduced recently (that was found by Claude Opus) and will be needed to update the buck binaries.