### PR TITLE
[automerge] ci: disable buck2-logs upload to deno.dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,10 +109,11 @@ jobs:
             --build-report ${{ runner.temp }}/build-report.json \
             --build-report-options fill-out-failures -- \
             --env SEMGREP_ENABLE_VERSION_CHECK=0
-      - name: Upload build logs
-        if: always()
-        shell: bash
-        run: buck2 run //src/tools/buck2-logs:upload -- --host https://buck2-logs.deno.dev
+      # NOTE (2026-07-19): disabled, blowing through deno.dev usage limits
+      #- name: Upload build logs
+      #  if: always()
+      #  shell: bash
+      #  run: buck2 run //src/tools/buck2-logs:upload -- --host https://buck2-logs.deno.dev
       - name: Generate build report
         if: always()
         shell: bash
@@ -269,11 +270,12 @@ jobs:
           TARGET_COUNT: ${{ steps.determine-targets.outputs.target-count }}
           TARGET_FILE: ${{ steps.determine-targets.outputs.target-file }}
 
-      - name: Upload build logs
-        if: always()
-        continue-on-error: true
-        shell: bash
-        run: buck2 run //src/tools/buck2-logs:upload -- --host https://buck2-logs.deno.dev
+      # NOTE (2026-07-19): disabled, blowing through deno.dev usage limits
+      #- name: Upload build logs
+      #  if: always()
+      #  continue-on-error: true
+      #  shell: bash
+      #  run: buck2 run //src/tools/buck2-logs:upload -- --host https://buck2-logs.deno.dev
 
       - name: Report results
         if: always()


### PR DESCRIPTION
The `Upload build logs` steps in both the `integrate` and `target-determination` jobs run unconditionally on every matrix leg (6 uploads per push/PR), which is blowing through the deno.dev usage limits. Comment them out until we sort out the quota situation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cbg28yNb9TPDLkD27ipphB